### PR TITLE
Dispatch event with context

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -106,7 +106,7 @@ if(SUPPORT_EVENTS){
 
     Mikado["dispatch"] = Mikado.prototype.dispatch = function(id, target, event, event_target){
 
-        listener[id](target, event, event_target);
+        listener[id].call(this, target, event, event_target);
         return this;
     };
 


### PR DESCRIPTION
It allows reuse an event handler with a different instance of the Mikado