### PR TITLE
fix: Add export for typescript definition 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare class Mikado {
+export declare class Mikado {
     constructor(root: HTMLElement, template: Template, options?: Options);
     constructor(template: Template, options?: Options);
     add(data: Object, view?: Object, index?: number): Mikado;
@@ -46,7 +46,7 @@ declare class Mikado {
     where(payload: Object): Array<Object>;
 }
 
-declare namespace Mikado {
+export declare namespace Mikado {
     class array {
         constructor(array?: Array<Object>);
         concat(array: Array<Object>): array;


### PR DESCRIPTION
Get rid of the lint error `File 'node_modules/mikado/index.d.ts' is not a module.` when import the file.